### PR TITLE
Allow arena 0 to be specified explicitly

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2531,7 +2531,8 @@ imalloc_body(static_opts_t *sopts, dynamic_opts_t *dopts, tsd_t *tsd) {
 		 */
 		assert(dopts->tcache_ind == TCACHE_IND_AUTOMATIC ||
 		    dopts->tcache_ind == TCACHE_IND_NONE);
-		assert(dopts->arena_ind == ARENA_IND_AUTOMATIC);
+		assert(dopts->arena_ind == ARENA_IND_AUTOMATIC ||
+		    dopts->arena_ind == 0);
 		dopts->tcache_ind = TCACHE_IND_NONE;
 		/* We know that arena 0 has already been initialized. */
 		dopts->arena_ind = 0;


### PR DESCRIPTION
As seen in our tests when we override the global new allocator and perform allocations from the context we're cleaning up thread local data we may end up calling je_mallocx and explicitly specify arena 0 which cause jemalloc to fail an assert (before it explicitly change the allocation to use arena 0).

This asssert is currently blocking our upgrade of folly, and the effect of allowing arena 0 to be specified is harmless in this context (as jemalloc would change it to 0 on the next statement)

See https://github.com/jemalloc/jemalloc/issues/2791
See https://jira.issues.couchbase.com/browse/MB-65040