### PR TITLE
MB-65107: Add je_thread_cleanup() and nullify the tsd when freeing

### DIFF
--- a/include/jemalloc/internal/tsd_win.h
+++ b/include/jemalloc/internal/tsd_win.h
@@ -32,6 +32,10 @@ tsd_cleanup_wrapper(void) {
 		}
 	}
 	malloc_tsd_dalloc(wrapper);
+	if (!TlsSetValue(tsd_tsd, NULL)) {
+		malloc_write("<jemalloc>: Error clearing TSD\n");
+		abort();
+	}
 	return false;
 }
 

--- a/include/jemalloc/jemalloc_protos.h.in
+++ b/include/jemalloc/jemalloc_protos.h.in
@@ -53,6 +53,7 @@ JEMALLOC_EXPORT void JEMALLOC_NOTHROW	@je_@malloc_stats_print(
     const char *opts);
 JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW	@je_@malloc_usable_size(
     JEMALLOC_USABLE_SIZE_CONST void *ptr) JEMALLOC_CXX_THROW;
+JEMALLOC_EXPORT void JEMALLOC_NOTHROW	@je_@thread_cleanup() JEMALLOC_CXX_THROW;
 #ifdef JEMALLOC_HAVE_MALLOC_SIZE
 JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW	@je_@malloc_size(
     const void *ptr);

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -24,6 +24,7 @@
 #include "jemalloc/internal/sz.h"
 #include "jemalloc/internal/ticker.h"
 #include "jemalloc/internal/thread_event.h"
+#include "jemalloc/internal/tsd.h"
 #include "jemalloc/internal/util.h"
 
 /******************************************************************************/
@@ -4101,6 +4102,13 @@ je_malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void *ptr) {
 
 	LOG("core.malloc_usable_size.exit", "result: %zu", ret);
 	return ret;
+}
+
+JEMALLOC_EXPORT void JEMALLOC_NOTHROW
+je_thread_cleanup() {
+	#if defined(JEMALLOC_MALLOC_THREAD_CLEANUP) || defined(_WIN32)
+	_malloc_thread_cleanup();
+	#endif
 }
 
 #ifdef JEMALLOC_HAVE_MALLOC_SIZE


### PR DESCRIPTION
On Windows, we have seen that the tls callback is called before C++ thread_local destructors run. This means that malloc_tsd_dalloc is called before potential further alloc/free is done, leaving us with a dangling tsd_t returned by tsd_wrapper_get().

In order to workaround this, first we need to reset the tls storage to NULL. It can now get re-created if needed. Also, provide a new exported symbol je_tls_cleanup() which allows users which alloc/free at thread_local destruction to manually cleanup a potential re-created tsd_t.

The contract for the je_thread_cleanup() method is that it can be called at any point of the thread lifetime, and it will clear the thread tsd_t. The tsd_t will be re-created automatically if required again. Calling je_thread_cleanup() at the end of the thread lifetime ensures that there is not a memory leak in threads which allocate during thread exit.