### PR TITLE
Add je_thread_cleanup to public symbols list

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1056,7 +1056,7 @@ AC_ARG_WITH([export],
 fi]
 )
 
-public_syms="aligned_alloc calloc dallocx free mallctl mallctlbymib mallctlnametomib malloc malloc_conf malloc_conf_2_conf_harder malloc_message malloc_stats_print malloc_usable_size mallocx smallocx_${jemalloc_version_gid} nallocx posix_memalign rallocx realloc sallocx sdallocx xallocx"
+public_syms="aligned_alloc calloc dallocx free mallctl mallctlbymib mallctlnametomib malloc malloc_conf malloc_conf_2_conf_harder malloc_message malloc_stats_print malloc_usable_size thread_cleanup mallocx smallocx_${jemalloc_version_gid} nallocx posix_memalign rallocx realloc sallocx sdallocx xallocx"
 dnl Check for additional platform-specific public API functions.
 AC_CHECK_FUNC([memalign],
 	      [AC_DEFINE([JEMALLOC_OVERRIDE_MEMALIGN], [ ], [ ])


### PR DESCRIPTION
Otherwise, the symbol name is not correct on macOS.

Before:
  nm -gU lib/libjemalloc.a | grep je_th
  0000000000006c74 T _je_je_thread_cleanup
  0000000000000818 D _je_thp_mode_names

After:
  nm -gU lib/libjemalloc.a | grep je_th
  0000000000006c74 T _je_thread_cleanup
  0000000000000818 D _je_thp_mode_names