### PR TITLE
Fix json_stats mutexes test for configurable MALLCTL_ARENAS_ALL

### DIFF
--- a/test/unit/json_stats.c
+++ b/test/unit/json_stats.c
@@ -329,11 +329,15 @@ TEST_BEGIN(test_json_stats_mutexes) {
 
 	for (size_t i = 0; i < num_arena_mutexes; i++) {
 		/*
-		 * MALLCTL_ARENAS_ALL is 4096 representing all arenas in
-		 * mallctl queries.
+		 * MALLCTL_ARENAS_ALL selects the merged stats across all
+		 * arenas.  Its numeric value is not a fixed constant: with
+		 * --with-lg-tcache-limit it is computed as 2^(24 - limit)
+		 * (4096 by default, but e.g. 512 at limit 15), so stringify
+		 * the macro rather than hard-coding 4096.
 		 */
 		verify_mutex_json(arena_mutexes_section,
-		    "stats.arenas.4096.mutexes", arena_mutex_names[i]);
+		    "stats.arenas." STRINGIFY(MALLCTL_ARENAS_ALL) ".mutexes",
+		    arena_mutex_names[i]);
 	}
 
 	stats_buf_fini(&sbuf);


### PR DESCRIPTION
test_json_stats_mutexes hard-coded the arena index 4096 in the mallctl name "stats.arenas.4096.mutexes...", assuming MALLCTL_ARENAS_ALL == 4096.  That holds only for the default tcache limit.  Our downstream --with-lg-tcache-limit patch makes MALLCTL_ARENAS_ALL a configure-computed value of 2^(24 - limit): at the limit=15 we build with, it is 512, not 4096.  The test then queried a non-existent arena index and mallctl returned ENOENT, failing every assertion in the merged-arena mutex loop.

Stringify the MALLCTL_ARENAS_ALL macro instead of hard-coding the value, matching the usage documented in jemalloc_macros.h.  The test now passes for any --with-lg-tcache-limit setting; the change is test-only and does not affect the library.